### PR TITLE
Update environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
     - gimli
 dependencies:
     - python
-    - pandas
+    - pandas=1.3.4
     - pygimli=1.2.4
     - gempy
     - gemgis


### PR DESCRIPTION
Hi @florian-wagner 

I've had a look at the environment. Could we freeze pandas to version 1.3.4?
Every version above 1.4 currently breaks gempy unfortunately. A bit dependency-hell.

Hope that does not meddle too much with the other packages (specifically pygimli)

Best,
Jan